### PR TITLE
fix nim dependency

### DIFF
--- a/quickjwt.nimble
+++ b/quickjwt.nimble
@@ -7,5 +7,5 @@ license       = "MIT"
 srcDir = "src"
 
 # Deps
-requires "nim >= 1.1.1"
+requires "nim >= 1.0.4"
 


### PR DESCRIPTION
quickjwt.nimble indicates nim should be of version 1.1.1 while nim is only 1.0.6. Made that change.